### PR TITLE
LDFLAGS: add libpthread

### DIFF
--- a/cgo_flags.go
+++ b/cgo_flags.go
@@ -8,5 +8,5 @@ package jemalloc
 // #cgo darwin CFLAGS: -Idarwin_includes/internal/include -Idarwin_includes/internal/include/jemalloc/internal
 // #cgo linux CFLAGS: -Ilinux_includes/internal/include -Ilinux_includes/internal/include/jemalloc/internal
 // #cgo freebsd CFLAGS: -Ifreebsd_includes/internal/include -Ifreebsd_includes/internal/include/jemalloc/internal
-// #cgo LDFLAGS: -lm
+// #cgo LDFLAGS: -lm -lpthread
 import "C"


### PR DESCRIPTION
This is needed when using gccgo with ld.gold.

See https://github.com/golang/go/issues/15549.
