### PR TITLE
MACOSX: configure for 10.9

### DIFF
--- a/darwin_includes/internal/include/jemalloc/internal/jemalloc_internal_defs.h
+++ b/darwin_includes/internal/include/jemalloc/internal/jemalloc_internal_defs.h
@@ -59,7 +59,7 @@
 /*
  * Defined if os_unfair_lock_*() functions are available, as provided by Darwin.
  */
-#define JEMALLOC_OS_UNFAIR_LOCK 
+/* #undef JEMALLOC_OS_UNFAIR_LOCK */
 
 /*
  * Defined if OSSpin*() functions are available, as provided by Darwin, and
@@ -68,7 +68,7 @@
 #define JEMALLOC_OSSPIN 
 
 /* Defined if syscall(2) is usable. */
-/* #undef JEMALLOC_USE_SYSCALL */
+#define JEMALLOC_USE_SYSCALL 
 
 /*
  * Defined if secure_getenv(3) is available.

--- a/import.sh
+++ b/import.sh
@@ -9,7 +9,7 @@ curl -sL https://github.com/jemalloc/jemalloc/releases/download/4.4.0/jemalloc-4
 
 # You need to manually run the following code.
 # on OSX:
-# (cd internal && ./configure --enable-prof --with-jemalloc-prefix="")
+# (cd internal && MACOSX_DEPLOYMENT_TARGET=10.9 ./configure --enable-prof --with-jemalloc-prefix='')
 # <compare "Build parameters" in internal/Makefile to cgo flags in cgo_flags.go> and adjust the latter.
 # rm -r darwin_includes
 # git clean -Xn -- internal/include/jemalloc | sed 's/.* //' | xargs -I % rsync -R % darwin_includes/


### PR DESCRIPTION
Note that this version number matches the version in the main repo:
https://github.com/cockroachdb/cockroach/blob/11a5ae2/build/build-osx.sh#L8

Fixes #10.