### PR TITLE
musl: use gcc intrinsics instead of libgcc

### DIFF
--- a/import.sh
+++ b/import.sh
@@ -21,7 +21,7 @@ curl -sL https://github.com/jemalloc/jemalloc/releases/download/4.4.0/jemalloc-4
 # git clean -Xn -- internal/include/jemalloc | sed 's/.* //' | xargs -I % rsync -R % linux_glibc_includes/
 #
 # on Linux with musl:
-# (cd internal && echo 'je_cv_madv_free=no' > config.cache && ./configure --enable-prof -C && rm config.cache)
+# (cd internal && echo 'je_cv_madv_free=no' > config.cache && ./configure --enable-prof --disable-prof-libgcc -C && rm config.cache)
 # <compare "Build parameters" in internal/Makefile to cgo flags in cgo_flags.go> and adjust the latter.
 # rm -r linux_musl_includes
 # git clean -Xn -- internal/include/jemalloc | sed 's/.* //' | xargs -I % rsync -R % linux_musl_includes/

--- a/linux_musl_includes/internal/include/jemalloc/internal/jemalloc_internal_defs.h
+++ b/linux_musl_includes/internal/include/jemalloc/internal/jemalloc_internal_defs.h
@@ -146,10 +146,10 @@
 /* #undef JEMALLOC_PROF_LIBUNWIND */
 
 /* Use libgcc for profile backtracing if defined. */
-#define JEMALLOC_PROF_LIBGCC 
+/* #undef JEMALLOC_PROF_LIBGCC */
 
 /* Use gcc intrinsics for profile backtracing if defined. */
-/* #undef JEMALLOC_PROF_GCC */
+#define JEMALLOC_PROF_GCC 
 
 /*
  * JEMALLOC_TCACHE enables a thread-specific caching layer for small objects.


### PR DESCRIPTION
Using libgcc creates a deadlock on start. See
https://github.com/jemalloc/jemalloc/issues/585.