### PR TITLE
Control profiling via build tags on all platforms

### DIFF
--- a/darwin_includes/internal/include/jemalloc/internal/jemalloc_internal_defs.h
+++ b/darwin_includes/internal/include/jemalloc/internal/jemalloc_internal_defs.h
@@ -140,7 +140,7 @@
 #define JEMALLOC_STATS 
 
 /* JEMALLOC_PROF enables allocation profiling. */
-#define JEMALLOC_PROF 
+/* #undef JEMALLOC_PROF */
 
 /* Use libunwind for profile backtracing if defined. */
 /* #undef JEMALLOC_PROF_LIBUNWIND */
@@ -149,7 +149,7 @@
 /* #undef JEMALLOC_PROF_LIBGCC */
 
 /* Use gcc intrinsics for profile backtracing if defined. */
-#define JEMALLOC_PROF_GCC 
+/* #undef JEMALLOC_PROF_GCC */
 
 /*
  * JEMALLOC_TCACHE enables a thread-specific caching layer for small objects.

--- a/freebsd_includes/internal/include/jemalloc/internal/jemalloc_internal_defs.h
+++ b/freebsd_includes/internal/include/jemalloc/internal/jemalloc_internal_defs.h
@@ -140,7 +140,7 @@
 #define JEMALLOC_STATS 
 
 /* JEMALLOC_PROF enables allocation profiling. */
-#define JEMALLOC_PROF 
+/* #undef JEMALLOC_PROF */
 
 /* Use libunwind for profile backtracing if defined. */
 /* #undef JEMALLOC_PROF_LIBUNWIND */
@@ -149,7 +149,7 @@
 /* #undef JEMALLOC_PROF_LIBGCC */
 
 /* Use gcc intrinsics for profile backtracing if defined. */
-#define JEMALLOC_PROF_GCC 
+/* #undef JEMALLOC_PROF_GCC */
 
 /*
  * JEMALLOC_TCACHE enables a thread-specific caching layer for small objects.

--- a/import.sh
+++ b/import.sh
@@ -13,6 +13,9 @@ for source_file in $($MAKE sources); do
   ln -sf "$source_file" .
 done
 
+# TODO(tamird): restore --enable-prof on all ./configure lines below when
+# https://github.com/jemalloc/jemalloc/issues/585 is resolved.
+
 # You need to manually run the following code.
 # on OSX:
 # (cd internal && MACOSX_DEPLOYMENT_TARGET=10.9 ./configure --enable-prof --with-jemalloc-prefix='')
@@ -29,7 +32,7 @@ done
 # echo 'je_cv_madv_free=no' >> config.cache
 # echo 'je_cv_pthread_mutex_adaptive_np=no' >> config.cache
 # echo 'je_cv_thp=no' >> config.cache
-# ./configure -C # TODO(tamird): restore --enable-prof here when https://github.com/jemalloc/jemalloc/issues/585 is resolved
+# ./configure -C
 # rm config.cache
 # cd -
 # <compare "Build parameters" in internal/Makefile to cgo flags in cgo_flags.go> and adjust the latter.


### PR DESCRIPTION
Note that the freebsd headers were updated by hand.