### PR TITLE
Port CPU_SPINWAIT to __powerpc64__

### DIFF
--- a/internal/configure.ac
+++ b/internal/configure.ac
@@ -338,6 +338,7 @@ case "${host_cpu}" in
 	;;
   powerpc)
 	AC_DEFINE_UNQUOTED([HAVE_ALTIVEC], [ ])
+    CPU_SPINWAIT='__asm__ volatile("or 31,31,31")'
 	;;
   *)
 	;;

--- a/linux_includes/internal/include/jemalloc/internal/jemalloc_internal_defs.h
+++ b/linux_includes/internal/include/jemalloc/internal/jemalloc_internal_defs.h
@@ -21,7 +21,11 @@
  * Hyper-threaded CPUs may need a special instruction inside spin loops in
  * order to yield to another virtual CPU.
  */
+#if defined(__powerpc64__)
+#define CPU_SPINWAIT __asm__ volatile("or 31,31,31")
+#else
 #define CPU_SPINWAIT __asm__ volatile("pause")
+#endif
 
 /* Defined if C11 atomics are available. */
 #define JEMALLOC_C11ATOMICS 1


### PR DESCRIPTION
Hyper-threaded CPUs may need a special instruction inside spin loops in
order to yield to another virtual CPU. The 'pause' instruction that is
available for x86 is not supported on Power.
Apparently the extended mnemonics like yield, mdoio, and mdoom are not
actually implemented on POWER8, although mentioned in the ISA 2.07
document. The recommended magic bits are an 'or 31,31,31'.